### PR TITLE
Add OrcaReplay to AI & Context Efficiency

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Open-source, local-first, small, composable, and single-purpose tools are prefer
 
 - [YYLO](https://github.com/yylo-dev/yylo) - Command-line orchestrator that runs each coding-agent task in a dedicated branch/worktree with typed validation and merge boundaries, reducing context overhead and repetitive review work.
 
+- [OrcaReplay](https://github.com/Continuum-AI-Corp/OrcaReplay) - Records a coding-agent run below the harness — model traffic, shell exit codes, per-turn file changes and MCP calls on one timeline — then replays it offline with the network off, or forks it from a checkpoint onto a different model.
+
 ## Build & Test Efficiency
 
 - [mvn-lite](https://github.com/ejboy/agent-scripts) - Reduces noisy Maven output to compact success or failure output while preserving useful diagnostics.


### PR DESCRIPTION
Adds OrcaReplay to **AI & Context Efficiency**, after YYLO.

The efficiency angle here is what you don't have to redo. When a coding agent goes wrong, the usual recovery is to rerun the task and hope it fails the same way — which burns tokens and often doesn't reproduce. OrcaReplay records the session at the process and socket boundary, so the model traffic, the shell commands with their exit codes, the per-turn file changes and the MCP calls sit on one timeline, and then replays it with the network off: the recorded responses are served back, so the run reproduces byte-for-byte for free, on any machine, as many times as you like.

It also forks — rerun from a chosen checkpoint against a different model, earlier turns still served from the recording, so a comparison costs only the turns after the branch point rather than two full runs.

Fits the list's bias: local-first, no hosted component, no account. Apache-2.0, `npm i -g orcareplay`, Node 20+.

Noting the obvious for your editorial criteria: the repository is nine days old with 150 stars.
